### PR TITLE
Fix NCC workflow

### DIFF
--- a/.github/workflows/ncc.yml
+++ b/.github/workflows/ncc.yml
@@ -1,21 +1,14 @@
 name: ncc
 on:
   push:
-    tags-ignore:
+    # Can't push a build commit to a tag, so only run for branches
+    branches:
       - '**'
     paths:
+      # Include any files that could require rebuilding
       - 'package-lock.json'
       - 'src/**'
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 14
-      - run: npm ci
-      - uses: planningcenter/balto-utils/ncc@main
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+  ncc-build:
+    uses: planningcenter/balto-utils/.github/workflows/ncc.yml@v1


### PR DESCRIPTION
When I added the tag filter in #2, I accidentally broke the workflow for branch pushes (it would ignore them completely). We can have Github implicitly ignore all tags by only specifying a branch filter.

I also switched the setup over to the reusable workflow, for simplicity and shared setup. This is optional and I'll leave a suggestion to revert it if you'd prefer to go without it @gjack.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203308302349071